### PR TITLE
Add open DuckDB connection metric and clean session statement handles

### DIFF
--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -95,6 +95,12 @@ The following metric instruments are emitted:
 - `gizmosql.query.duration` (histogram, ms)
 - `gizmosql.bytes.transferred` (counter, By)
 - `gizmosql.connections.active` (up/down counter)
+- `gizmosql.duckdb.connections.open` (up/down counter)
+
+Metric semantics:
+
+- `gizmosql.connections.active` tracks active GizmoSQL sessions.
+- `gizmosql.duckdb.connections.open` tracks open DuckDB connection objects used by GizmoSQL, including session connections and internal utility/instrumentation connections.
 
 ### Logs
 

--- a/src/common/gizmosql_telemetry.cpp
+++ b/src/common/gizmosql_telemetry.cpp
@@ -69,6 +69,8 @@ static opentelemetry::nostd::unique_ptr<metrics_api::Counter<uint64_t>>
 static opentelemetry::nostd::unique_ptr<metrics_api::Counter<uint64_t>> g_bytes_counter;
 static opentelemetry::nostd::unique_ptr<metrics_api::UpDownCounter<int64_t>>
     g_active_connections;
+static opentelemetry::nostd::unique_ptr<metrics_api::UpDownCounter<int64_t>>
+    g_open_duckdb_connections;
 
 static otlp::OtlpHeaders ParseHeaders(const std::string& headers_str) {
   otlp::OtlpHeaders headers;
@@ -315,6 +317,8 @@ static void InitMetricsInstruments() {
                                                "Number of bytes transferred", "By");
   g_active_connections = meter->CreateInt64UpDownCounter(
       "gizmosql.connections.active", "Number of active connections", "1");
+  g_open_duckdb_connections = meter->CreateInt64UpDownCounter(
+      "gizmosql.duckdb.connections.open", "Number of open DuckDB connections", "1");
   g_metrics_initialized = true;
 }
 
@@ -351,6 +355,12 @@ void RecordActiveConnections(int64_t count) {
   g_active_connections->Add(count, {}, opentelemetry::context::Context{});
 }
 
+void RecordOpenDuckDBConnections(int64_t count) {
+  if (!IsTelemetryEnabled()) return;
+  InitMetricsInstruments();
+  g_open_duckdb_connections->Add(count, {}, opentelemetry::context::Context{});
+}
+
 void RecordBytesTransferred(const std::string& direction, int64_t bytes) {
   if (!IsTelemetryEnabled() || bytes < 0) return;
   InitMetricsInstruments();
@@ -369,6 +379,7 @@ namespace metrics {
 void RecordRpcCall(const std::string&, const std::string&, double) {}
 void RecordQueryExecution(const std::string&, const std::string&, double) {}
 void RecordActiveConnections(int64_t) {}
+void RecordOpenDuckDBConnections(int64_t) {}
 void RecordBytesTransferred(const std::string&, int64_t) {}
 
 }  // namespace metrics

--- a/src/common/include/detail/gizmosql_telemetry.h
+++ b/src/common/include/detail/gizmosql_telemetry.h
@@ -164,6 +164,9 @@ void RecordQueryExecution(const std::string& operation,
 // Record active connections
 void RecordActiveConnections(int64_t count);
 
+// Record open DuckDB connection delta (+1 open, -1 close)
+void RecordOpenDuckDBConnections(int64_t count);
+
 // Record bytes transferred
 void RecordBytesTransferred(const std::string& direction, int64_t bytes);
 

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -46,6 +46,7 @@
 #include "duckdb_tables_schema_batch_reader.h"
 #include "gizmosql_security.h"
 #include "gizmosql_logging.h"
+#include "gizmosql_telemetry.h"
 #include "telemetry_middleware.h"
 #include "flight_sql_fwd.h"
 #include "session_context.h"
@@ -104,6 +105,15 @@ class DuckDBTransactionGuard {
   bool committed_;
 };
 
+class ScopedDuckDBConnectionCounter {
+ public:
+  ScopedDuckDBConnectionCounter() {
+    ::gizmosql::metrics::RecordOpenDuckDBConnections(1);
+  }
+  ~ScopedDuckDBConnectionCounter() {
+    ::gizmosql::metrics::RecordOpenDuckDBConnections(-1);
+  }
+};
 duckdb::LogicalType GetDuckDBTypeFromArrowType(
     const std::shared_ptr<arrow::DataType>& arrow_type) {
   using arrow::Type;
@@ -803,6 +813,47 @@ class DuckDBFlightSqlServer::Impl {
     return search->second;
   }
 
+  int64_t RemovePreparedStatementsForSession(const std::string& session_id) {
+    std::unique_lock write_lock(statements_mutex_);
+    int64_t removed_count = 0;
+
+    for (auto it = prepared_statements_.begin(); it != prepared_statements_.end();) {
+      if (it->second && it->second->GetSessionId() == session_id) {
+        it = prepared_statements_.erase(it);
+        removed_count++;
+      } else {
+        ++it;
+      }
+    }
+
+    return removed_count;
+  }
+
+  void FinalizeSessionRemoval(const std::string& session_id) {
+    const auto removed_stmt_count = RemovePreparedStatementsForSession(session_id);
+    if (removed_stmt_count > 0) {
+      GIZMOSQL_LOG(INFO) << "Released " << removed_stmt_count
+                         << " prepared statement(s) for session " << session_id;
+    }
+    ::gizmosql::metrics::RecordActiveConnections(-1);
+  }
+
+  std::shared_ptr<duckdb::Connection> CreateTrackedSessionConnection() const {
+    duckdb::Connection* raw_connection = new duckdb::Connection(*db_instance_);
+    try {
+      std::shared_ptr<duckdb::Connection> tracked_connection(
+          raw_connection, [](duckdb::Connection* conn) {
+            delete conn;
+            ::gizmosql::metrics::RecordOpenDuckDBConnections(-1);
+          });
+      ::gizmosql::metrics::RecordOpenDuckDBConnections(1);
+      return tracked_connection;
+    } catch (...) {
+      delete raw_connection;
+      throw;
+    }
+  }
+
   static std::optional<std::string> SessionValueToString(
       const flight::SessionOptionValue& v) {
     if (auto p = std::get_if<std::string>(&v)) return *p;
@@ -838,11 +889,15 @@ class DuckDBFlightSqlServer::Impl {
         if (it->second->kill_requested) {
           // Release the read lock before taking the write lock
           read_lock.unlock();
-          // Remove the killed session from the map
+          bool removed_session = false;
           {
             std::unique_lock write_lock(sessions_mutex_);
-            client_sessions_.erase(session_id);
+            const auto erased_count = client_sessions_.erase(session_id);
             killed_session_ids_.insert(session_id);
+            removed_session = erased_count > 0;
+          }
+          if (removed_session) {
+            FinalizeSessionRemoval(session_id);
           }
           return Status::Invalid(
               "Your session has been killed. Please re-connect.");
@@ -865,7 +920,7 @@ class DuckDBFlightSqlServer::Impl {
     new_session->user_agent = tl_request_ctx.user_agent.value_or("");
     new_session->connection_protocol = tl_request_ctx.connection_protocol.value_or("plaintext");
     new_session->catalog_access = tl_request_ctx.catalog_access.value_or(std::vector<CatalogAccessRule>{});
-    new_session->connection = std::make_shared<duckdb::Connection>(*db_instance_);
+    new_session->connection = CreateTrackedSessionConnection();
     new_session->query_timeout = query_timeout_;
     new_session->query_log_level = query_log_level_;
 
@@ -902,8 +957,12 @@ class DuckDBFlightSqlServer::Impl {
       if (auto it = client_sessions_.find(session_id); it != client_sessions_.end()) {
         // Another thread won the race – but check if it was killed
         if (it->second->kill_requested) {
-          client_sessions_.erase(session_id);
+          const auto erased_count = client_sessions_.erase(session_id);
           killed_session_ids_.insert(session_id);
+          write_lock.unlock();
+          if (erased_count > 0) {
+            FinalizeSessionRemoval(session_id);
+          }
           return Status::Invalid(
               "Your session has been killed. Please re-connect.");
         }
@@ -912,6 +971,7 @@ class DuckDBFlightSqlServer::Impl {
       }
 
       client_sessions_[session_id] = new_session;
+      ::gizmosql::metrics::RecordActiveConnections(1);
       GIZMOSQL_LOGKV_SESSION(INFO, new_session, "Client session was successfully created.",
                      {"kind", "session_create"}, {"status", "success"},
                      {"auth_method", new_session->auth_method});
@@ -1007,6 +1067,10 @@ class DuckDBFlightSqlServer::Impl {
       auto session_count = client_sessions_.size();
       client_sessions_.clear();
       if (session_count > 0) {
+        ::gizmosql::metrics::RecordActiveConnections(
+            -static_cast<int64_t>(session_count));
+      }
+      if (session_count > 0) {
         GIZMOSQL_LOG(INFO) << "Released " << session_count << " active session(s) during shutdown";
       }
     }
@@ -1030,17 +1094,22 @@ class DuckDBFlightSqlServer::Impl {
   }
 
   arrow::Status RemoveSession(const std::string& session_id, bool was_killed = false) {
-    std::unique_lock write_lock(sessions_mutex_);
-    auto it = client_sessions_.find(session_id);
-    if (it != client_sessions_.end()) {
-      client_sessions_.erase(it);
-      // If the session was killed, remember the session_id to prevent reconnection
-      if (was_killed) {
-        killed_session_ids_.insert(session_id);
+    {
+      std::unique_lock write_lock(sessions_mutex_);
+      auto it = client_sessions_.find(session_id);
+      if (it != client_sessions_.end()) {
+        client_sessions_.erase(it);
+        // If the session was killed, remember the session_id to prevent reconnection
+        if (was_killed) {
+          killed_session_ids_.insert(session_id);
+        }
+      } else {
+        return arrow::Status::KeyError("Session not found: " + session_id);
       }
-      return arrow::Status::OK();
     }
-    return arrow::Status::KeyError("Session not found: " + session_id);
+
+    FinalizeSessionRemoval(session_id);
+    return arrow::Status::OK();
   }
 
   ~Impl() = default;
@@ -1809,10 +1878,8 @@ class DuckDBFlightSqlServer::Impl {
       const flight::ServerCallContext& context,
       const flight::CloseSessionRequest& request) {
     ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
-    std::unique_lock write_lock(sessions_mutex_);
-    auto it = client_sessions_.find(client_session->session_id);
-    if (it != client_sessions_.end()) {
-      client_sessions_.erase(it);
+    const auto remove_status = RemoveSession(client_session->session_id);
+    if (remove_status.ok()) {
       GIZMOSQL_LOGKV_SESSION(INFO, client_session, "Client session was successfully closed.",
                      {"kind", "session_close"}, {"status", "success"});
       return flight::CloseSessionResult(flight::CloseSessionStatus::kClosed);
@@ -1836,6 +1903,7 @@ class DuckDBFlightSqlServer::Impl {
   Status ExecuteSql(const std::string& sql) const {
     // We do not have a call context, so just grab a new connection to the instance
     auto connection = std::make_shared<duckdb::Connection>(*db_instance_);
+    ScopedDuckDBConnectionCounter scoped_connection_counter;
     return ExecuteSql(connection, sql);
   }
 
@@ -1869,6 +1937,7 @@ class DuckDBFlightSqlServer::Impl {
   Result<std::vector<std::string>> ExecuteSqlAndGetStringVector(const std::string& sql) {
     // We do not have a call context, so just grab a new connection to the instance
     auto connection = std::make_shared<duckdb::Connection>(*db_instance_);
+    ScopedDuckDBConnectionCounter scoped_connection_counter;
 
     return ExecuteSqlAndGetStringVector(connection, sql);
   }

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -1372,6 +1372,11 @@ long DuckDBStatement::GetLastExecutionDurationMs() const {
       .count();
 }
 
+std::string DuckDBStatement::GetSessionId() const {
+  if (!client_session_) return "";
+  return client_session_->session_id;
+}
+
 arrow::Result<std::shared_ptr<arrow::Schema>> DuckDBStatement::ComputeSchema() {
   std::string status;
 

--- a/src/duckdb/duckdb_statement.h
+++ b/src/duckdb/duckdb_statement.h
@@ -87,6 +87,8 @@ class DuckDBStatement {
 
   long GetLastExecutionDurationMs() const;
 
+  std::string GetSessionId() const;
+
   duckdb::vector<duckdb::Value> bind_parameters;
 
 #ifdef GIZMOSQL_ENTERPRISE

--- a/src/enterprise/instrumentation/instrumentation_manager.cpp
+++ b/src/enterprise/instrumentation/instrumentation_manager.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 
 #include "gizmosql_logging.h"
+#include "gizmosql_telemetry.h"
 
 namespace fs = std::filesystem;
 
@@ -281,7 +282,11 @@ InstrumentationManager::InstrumentationManager(
       schema_(schema),
       use_external_catalog_(use_external_catalog),
       db_instance_(std::move(db_instance)),
-      writer_connection_(std::move(writer_connection)) {}
+      writer_connection_(std::move(writer_connection)) {
+  if (writer_connection_) {
+    ::gizmosql::metrics::RecordOpenDuckDBConnections(1);
+  }
+}
 
 InstrumentationManager::~InstrumentationManager() { Shutdown(); }
 
@@ -519,6 +524,11 @@ void InstrumentationManager::Shutdown() {
 
   if (writer_thread_.joinable()) {
     writer_thread_.join();
+  }
+
+  if (writer_connection_) {
+    writer_connection_.reset();
+    ::gizmosql::metrics::RecordOpenDuckDBConnections(-1);
   }
 
   GIZMOSQL_LOG(INFO) << "Instrumentation manager shutdown complete";


### PR DESCRIPTION
## Summary
- add a new OpenTelemetry up/down counter `gizmosql.duckdb.connections.open`
- track DuckDB connection lifecycle for session connections, instrumentation writer connection, and short-lived internal utility connections
- clean prepared statement handles for a session when that session is removed/closed/killed to avoid retained session references
- update OpenTelemetry docs with the new metric semantics

## Why
`gizmosql.connections.active` tracks active GizmoSQL sessions, but we also need visibility into open DuckDB connection objects and to prevent stale prepared-statement handles from keeping session connections alive.

## Testing
- `cmake` is not available in this environment, so I could not run build/tests locally in this session.
- Ran `git diff --check` to validate patch formatting.
