### PR TITLE
Restrict metadata visibility for catalog-scoped tokens

### DIFF
--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -52,6 +52,7 @@
 #include "session_context.h"
 #include "request_ctx.h"
 #ifdef GIZMOSQL_ENTERPRISE
+#include "enterprise/catalog_permissions/catalog_permissions_handler.h"
 #include "enterprise/instrumentation/instrumentation_manager.h"
 #include "enterprise/instrumentation/instrumentation_records.h"
 #endif
@@ -262,6 +263,37 @@ std::string QuoteIdent(const std::string& name) {
   q += "\"";
   return q;
 }
+
+bool HasSqlLikeWildcard(const std::string& value) {
+  return value.find('%') != std::string::npos || value.find('_') != std::string::npos;
+}
+
+#ifdef GIZMOSQL_ENTERPRISE
+std::shared_ptr<InstrumentationManager> GetInstrumentationManagerForSession(
+    const std::shared_ptr<ClientSession>& client_session) {
+  if (auto server = GetServer(*client_session)) {
+    return server->GetInstrumentationManager();
+  }
+  return nullptr;
+}
+
+arrow::Status EnsureReadableCatalog(
+    const std::shared_ptr<ClientSession>& client_session,
+    const std::string& catalog_name) {
+  return gizmosql::enterprise::EnsureCatalogReadAccess(
+      *client_session, catalog_name, GetInstrumentationManagerForSession(client_session));
+}
+
+std::string BuildMetadataCatalogFilterSqlForSession(
+    const std::shared_ptr<ClientSession>& client_session,
+    const std::string& column_name,
+    duckdb::vector<duckdb::Value>& bind_parameters) {
+  auto filter = gizmosql::enterprise::GetMetadataCatalogFilter(
+      *client_session, GetInstrumentationManagerForSession(client_session));
+  return gizmosql::enterprise::BuildMetadataCatalogFilterSql(
+      filter, column_name, bind_parameters);
+}
+#endif
 
 Result<bool> TableExists(duckdb::Connection& conn,
                          const std::optional<std::string>& catalog_name,
@@ -651,7 +683,8 @@ arrow::Status AppendRecordBatchToDuckDB(
 }
 
 std::string PrepareQueryForGetTables(const sql::GetTables& command,
-                                     duckdb::vector<duckdb::Value>& bind_parameters) {
+                                     duckdb::vector<duckdb::Value>& bind_parameters,
+                                     const std::string& metadata_catalog_filter_sql = "") {
   std::stringstream table_query;
 
   table_query << "SELECT table_catalog as catalog_name, table_schema as db_schema_name, "
@@ -665,6 +698,10 @@ std::string PrepareQueryForGetTables(const sql::GetTables& command,
   } else {
     table_query << "= CURRENT_DATABASE()";
   }
+
+#ifdef GIZMOSQL_ENTERPRISE
+  table_query << metadata_catalog_filter_sql;
+#endif
 
   if (command.db_schema_filter_pattern.has_value()) {
     table_query << " and table_schema LIKE ?";
@@ -1129,12 +1166,17 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetCatalogs(
       const flight::ServerCallContext& context) {
-    std::string query =
-        "SELECT DISTINCT catalog_name FROM information_schema.schemata ORDER BY "
-        "catalog_name";
-
     ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
-    return DoGetDuckDBQuery(client_session, query, sql::SqlSchema::GetCatalogsSchema(),
+    duckdb::vector<duckdb::Value> bind_parameters;
+    std::stringstream query;
+    query << "SELECT DISTINCT catalog_name FROM information_schema.schemata WHERE 1 = 1";
+#ifdef GIZMOSQL_ENTERPRISE
+    query << BuildMetadataCatalogFilterSqlForSession(client_session, "catalog_name",
+                                                     bind_parameters);
+#endif
+    query << " ORDER BY catalog_name";
+    return DoGetDuckDBQuery(client_session, query.str(), sql::SqlSchema::GetCatalogsSchema(),
+                            bind_parameters,
                             print_queries_, query_timeout_, "DoGetCatalogs", true);
   }
 
@@ -1146,6 +1188,7 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetDbSchemas(
       const flight::ServerCallContext& context, const sql::GetDbSchemas& command) {
+    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     std::stringstream query;
     duckdb::vector<duckdb::Value> bind_parameters;
     query << "SELECT catalog_name, schema_name AS db_schema_name FROM "
@@ -1153,11 +1196,21 @@ class DuckDBFlightSqlServer::Impl {
 
     query << " AND catalog_name = ";
     if (command.catalog.has_value()) {
+#ifdef GIZMOSQL_ENTERPRISE
+      if (!HasSqlLikeWildcard(command.catalog.value())) {
+        ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, command.catalog.value()));
+      }
+#endif
       query << "?";
       bind_parameters.emplace_back(command.catalog.value());
     } else {
       query << "CURRENT_DATABASE()";
     }
+
+#ifdef GIZMOSQL_ENTERPRISE
+    query << BuildMetadataCatalogFilterSqlForSession(client_session, "catalog_name",
+                                                     bind_parameters);
+#endif
 
     if (command.db_schema_filter_pattern.has_value()) {
       query << " AND schema_name LIKE ?";
@@ -1165,7 +1218,6 @@ class DuckDBFlightSqlServer::Impl {
     }
     query << " ORDER BY catalog_name, db_schema_name";
 
-    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     return DoGetDuckDBQuery(client_session, query.str(),
                             sql::SqlSchema::GetDbSchemasSchema(), bind_parameters,
                             print_queries_, query_timeout_, "DoGetDbSchemas", true);
@@ -1294,11 +1346,23 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetTables(
       const flight::ServerCallContext& context, const sql::GetTables& command) {
-    duckdb::vector<duckdb::Value> get_tables_bind_parameters;
-    std::string get_tables_query =
-        PrepareQueryForGetTables(command, get_tables_bind_parameters);
-    std::shared_ptr<DuckDBStatement> statement;
     ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
+    duckdb::vector<duckdb::Value> get_tables_bind_parameters;
+#ifdef GIZMOSQL_ENTERPRISE
+    if (command.catalog.has_value() &&
+        !HasSqlLikeWildcard(command.catalog.value())) {
+      ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, command.catalog.value()));
+    }
+    const std::string metadata_catalog_filter_sql =
+        BuildMetadataCatalogFilterSqlForSession(client_session, "table_catalog",
+                                                get_tables_bind_parameters);
+#else
+    const std::string metadata_catalog_filter_sql;
+#endif
+    std::string get_tables_query =
+        PrepareQueryForGetTables(command, get_tables_bind_parameters,
+                                 metadata_catalog_filter_sql);
+    std::shared_ptr<DuckDBStatement> statement;
     ARROW_ASSIGN_OR_RAISE(
         statement,
         DuckDBStatement::Create(client_session, get_tables_query,
@@ -1391,6 +1455,7 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetPrimaryKeys(
       const flight::ServerCallContext& context, const sql::GetPrimaryKeys& command) {
+    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     std::stringstream table_query;
     duckdb::vector<duckdb::Value> bind_parameters;
 
@@ -1413,10 +1478,17 @@ class DuckDBFlightSqlServer::Impl {
     const sql::TableRef& table_ref = command.table_ref;
     table_query << " AND catalog_name = ";
     if (table_ref.catalog.has_value()) {
+#ifdef GIZMOSQL_ENTERPRISE
+      ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, table_ref.catalog.value()));
+#endif
       table_query << "?";
       bind_parameters.emplace_back(table_ref.catalog.value());
     } else {
       table_query << "CURRENT_DATABASE()";
+#ifdef GIZMOSQL_ENTERPRISE
+      table_query << BuildMetadataCatalogFilterSqlForSession(client_session, "catalog_name",
+                                                             bind_parameters);
+#endif
     }
 
     if (table_ref.db_schema.has_value()) {
@@ -1427,7 +1499,6 @@ class DuckDBFlightSqlServer::Impl {
     table_query << " and table_name LIKE ?";
     bind_parameters.emplace_back(table_ref.table);
 
-    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     return DoGetDuckDBQuery(client_session, table_query.str(),
                             sql::SqlSchema::GetPrimaryKeysSchema(), bind_parameters,
                             print_queries_, query_timeout_, "DoGetPrimaryKeys", true);
@@ -1441,6 +1512,7 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetImportedKeys(
       const flight::ServerCallContext& context, const sql::GetImportedKeys& command) {
+    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     const sql::TableRef& table_ref = command.table_ref;
     duckdb::vector<duckdb::Value> bind_parameters;
 
@@ -1449,11 +1521,21 @@ class DuckDBFlightSqlServer::Impl {
 
     filter += " AND fk_catalog_name = ";
     if (table_ref.catalog.has_value()) {
+#ifdef GIZMOSQL_ENTERPRISE
+      ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, table_ref.catalog.value()));
+#endif
       filter += "?";
       bind_parameters.emplace_back(table_ref.catalog.value());
     } else {
       filter += "CURRENT_DATABASE()";
     }
+
+#ifdef GIZMOSQL_ENTERPRISE
+    filter += BuildMetadataCatalogFilterSqlForSession(client_session, "fk_catalog_name",
+                                                      bind_parameters);
+    filter += BuildMetadataCatalogFilterSqlForSession(client_session, "pk_catalog_name",
+                                                      bind_parameters);
+#endif
 
     if (table_ref.db_schema.has_value()) {
       filter += " AND fk_schema_name = ?";
@@ -1462,7 +1544,6 @@ class DuckDBFlightSqlServer::Impl {
 
     std::string query = PrepareQueryForGetImportedOrExportedKeys(filter);
 
-    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     return DoGetDuckDBQuery(client_session, query,
                             sql::SqlSchema::GetImportedKeysSchema(), bind_parameters,
                             print_queries_, query_timeout_, "DoGetImportedKeys", true);
@@ -1476,6 +1557,7 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetExportedKeys(
       const flight::ServerCallContext& context, const sql::GetExportedKeys& command) {
+    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     const sql::TableRef& table_ref = command.table_ref;
     duckdb::vector<duckdb::Value> bind_parameters;
 
@@ -1485,11 +1567,21 @@ class DuckDBFlightSqlServer::Impl {
     filter += " AND pk_catalog_name = ";
 
     if (table_ref.catalog.has_value()) {
+#ifdef GIZMOSQL_ENTERPRISE
+      ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, table_ref.catalog.value()));
+#endif
       filter += "?";
       bind_parameters.emplace_back(table_ref.catalog.value());
     } else {
       filter += "CURRENT_DATABASE()";
     }
+
+#ifdef GIZMOSQL_ENTERPRISE
+    filter += BuildMetadataCatalogFilterSqlForSession(client_session, "pk_catalog_name",
+                                                      bind_parameters);
+    filter += BuildMetadataCatalogFilterSqlForSession(client_session, "fk_catalog_name",
+                                                      bind_parameters);
+#endif
 
     if (table_ref.db_schema.has_value()) {
       filter += " AND pk_schema_name = ?";
@@ -1497,7 +1589,6 @@ class DuckDBFlightSqlServer::Impl {
     }
     std::string query = PrepareQueryForGetImportedOrExportedKeys(filter);
 
-    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     return DoGetDuckDBQuery(client_session, query,
                             sql::SqlSchema::GetExportedKeysSchema(), bind_parameters,
                             print_queries_, query_timeout_, "DoGetExportedKeys", true);
@@ -1511,6 +1602,7 @@ class DuckDBFlightSqlServer::Impl {
 
   Result<std::unique_ptr<flight::FlightDataStream>> DoGetCrossReference(
       const flight::ServerCallContext& context, const sql::GetCrossReference& command) {
+    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     const sql::TableRef& pk_table_ref = command.pk_table_ref;
     duckdb::vector<duckdb::Value> bind_parameters;
 
@@ -1519,6 +1611,9 @@ class DuckDBFlightSqlServer::Impl {
 
     filter += " AND pk_catalog_name = ";
     if (pk_table_ref.catalog.has_value()) {
+#ifdef GIZMOSQL_ENTERPRISE
+      ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, pk_table_ref.catalog.value()));
+#endif
       filter += "?";
       bind_parameters.emplace_back(pk_table_ref.catalog.value());
     } else {
@@ -1536,11 +1631,21 @@ class DuckDBFlightSqlServer::Impl {
 
     filter += " AND fk_catalog_name = ";
     if (fk_table_ref.catalog.has_value()) {
+#ifdef GIZMOSQL_ENTERPRISE
+      ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, fk_table_ref.catalog.value()));
+#endif
       filter += "?";
       bind_parameters.emplace_back(fk_table_ref.catalog.value());
     } else {
       filter += "CURRENT_DATABASE()";
     }
+
+#ifdef GIZMOSQL_ENTERPRISE
+    filter += BuildMetadataCatalogFilterSqlForSession(client_session, "pk_catalog_name",
+                                                      bind_parameters);
+    filter += BuildMetadataCatalogFilterSqlForSession(client_session, "fk_catalog_name",
+                                                      bind_parameters);
+#endif
 
     if (fk_table_ref.db_schema.has_value()) {
       filter += " AND fk_schema_name = ?";
@@ -1548,7 +1653,6 @@ class DuckDBFlightSqlServer::Impl {
     }
     std::string query = PrepareQueryForGetImportedOrExportedKeys(filter);
 
-    ARROW_ASSIGN_OR_RAISE(auto client_session, GetClientSession(context));
     return DoGetDuckDBQuery(client_session, query,
                             sql::SqlSchema::GetCrossReferenceSchema(), bind_parameters,
                             print_queries_, query_timeout_, "DoGetCrossReference", true);
@@ -1813,6 +1917,11 @@ class DuckDBFlightSqlServer::Impl {
         std::string sanitized =
             boost::algorithm::erase_all_copy(std::get<std::string>(value), "\"");
         std::string quoted_identifier = "\"" + sanitized + "\"";
+#ifdef GIZMOSQL_ENTERPRISE
+        if (name == "catalog") {
+          ARROW_RETURN_NOT_OK(EnsureReadableCatalog(client_session, sanitized));
+        }
+#endif
         ARROW_RETURN_NOT_OK(ExecuteSql(client_session, "USE " + quoted_identifier));
       } else {
         res.errors.emplace(name, flight::SetSessionOptionsResult::Error{

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -267,6 +267,25 @@ bool QueryTouchesRestrictedMetadataSource(const std::string& upper_sql) {
          upper_sql.find("DUCKDB_CONSTRAINTS()") != std::string::npos;
 }
 
+std::optional<std::string> GetDeniedRestrictedMetadataFunction(
+    const std::string& upper_sql) {
+  static const std::vector<std::string> kDeniedFunctions = {
+      "DUCKDB_DATABASES()",
+      "DUCKDB_TABLES()",
+      "DUCKDB_COLUMNS()",
+      "DUCKDB_SCHEMAS()",
+      "DUCKDB_VIEWS()",
+  };
+
+  for (const auto& function_name : kDeniedFunctions) {
+    if (upper_sql.find(function_name) != std::string::npos) {
+      return boost::to_lower_copy(function_name);
+    }
+  }
+
+  return std::nullopt;
+}
+
 bool IsRestrictedMetadataQueryTooComplex(const std::string& upper_sql) {
   static const std::vector<std::string> forbidden_tokens = {
       " JOIN ",    " GROUP BY ", " HAVING ",   " OVER(",
@@ -823,6 +842,11 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
         return Status::Invalid(
             "Access denied: SHOW ALL TABLES is not allowed for catalog-restricted "
             "tokens. Use SHOW TABLES after selecting an allowed catalog.");
+      } else if (auto denied_function =
+                     GetDeniedRestrictedMetadataFunction(upper_sql)) {
+        return Status::Invalid(
+            "Access denied: " + *denied_function +
+            " is not allowed for catalog-restricted tokens.");
       } else if (QueryTouchesRestrictedMetadataSource(upper_sql)) {
         if (IsRestrictedMetadataQueryTooComplex(upper_sql)) {
           return Status::Invalid(

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -145,6 +145,76 @@ bool IsDetachInstrumentationDb(const std::string& sql, const std::string& instru
   return false;
 }
 
+std::string UnquoteIdentifier(const std::string& identifier) {
+  if (identifier.size() >= 2 && identifier.front() == '"' && identifier.back() == '"') {
+    std::string unquoted = identifier.substr(1, identifier.size() - 2);
+    boost::replace_all(unquoted, "\"\"", "\"");
+    return unquoted;
+  }
+  return identifier;
+}
+
+std::optional<std::string> TryExtractUseCatalogName(const std::string& sql) {
+  static const std::regex use_pattern(
+      R"(^\s*USE\s+((?:"(?:[^"]|"")+"|[A-Za-z_][A-Za-z0-9_]*))(?:\s*\.\s*((?:"(?:[^"]|"")+"|[A-Za-z_][A-Za-z0-9_]*)))?\s*;?\s*$)",
+      std::regex_constants::icase);
+
+  std::smatch match;
+  if (!std::regex_match(sql, match, use_pattern)) {
+    return std::nullopt;
+  }
+
+  const std::string first_identifier = UnquoteIdentifier(match[1].str());
+  if (match[2].matched) {
+    return first_identifier;
+  }
+
+  return first_identifier;
+}
+
+bool CatalogExistsOnConnection(const std::shared_ptr<duckdb::Connection>& connection,
+                               const std::string& catalog_name) {
+  auto stmt = connection->Prepare(
+      "SELECT 1 FROM information_schema.schemata WHERE catalog_name = ? LIMIT 1");
+  if (!stmt || !stmt->success) {
+    return false;
+  }
+
+  duckdb::vector<duckdb::Value> bind_parameters;
+  bind_parameters.emplace_back(catalog_name);
+  auto result = stmt->Execute(bind_parameters);
+  if (!result || result->HasError()) {
+    return false;
+  }
+
+  auto row = result->Fetch();
+  return row != nullptr && row->size() > 0;
+}
+
+bool QueryTouchesRestrictedMetadataSource(const std::string& upper_sql) {
+  return upper_sql.find("INFORMATION_SCHEMA.TABLES") != std::string::npos ||
+         upper_sql.find("INFORMATION_SCHEMA.SCHEMATA") != std::string::npos ||
+         upper_sql.find("INFORMATION_SCHEMA.COLUMNS") != std::string::npos ||
+         upper_sql.find("DUCKDB_CONSTRAINTS()") != std::string::npos;
+}
+
+bool IsRestrictedMetadataQueryTooComplex(const std::string& upper_sql) {
+  static const std::vector<std::string> forbidden_tokens = {
+      " JOIN ",    " GROUP BY ", " HAVING ",   " OVER(",
+      " OVER (",   " UNION ",    " EXCEPT ",   " INTERSECT ",
+      " COUNT(",   " SUM(",      " AVG(",      " MIN(",
+      " MAX(",     " STRING_AGG(", " ARRAY_AGG(",
+  };
+
+  for (const auto& token : forbidden_tokens) {
+    if (upper_sql.find(token) != std::string::npos) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 #ifndef GIZMOSQL_ENTERPRISE
 // Core edition: local implementation for detection only
 bool IsKillSessionCommand(const std::string& sql, std::string& target_session_id) {
@@ -659,27 +729,50 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
         {"sql", logged_sql});
   }
 
+#ifdef GIZMOSQL_ENTERPRISE
+  std::shared_ptr<InstrumentationManager> instr_mgr;
+  if (auto server = GetServer(*client_session)) {
+    instr_mgr = server->GetInstrumentationManager();
+  }
+
+  std::optional<gizmosql::enterprise::MetadataCatalogFilter> restricted_metadata_filter;
+  if (!is_internal) {
+    if (auto use_catalog_name = TryExtractUseCatalogName(sql)) {
+      if (CatalogExistsOnConnection(client_session->connection, *use_catalog_name)) {
+        ARROW_RETURN_NOT_OK(gizmosql::enterprise::EnsureCatalogReadAccess(
+            *client_session, *use_catalog_name, instr_mgr));
+      }
+    }
+
+    auto metadata_filter =
+        gizmosql::enterprise::GetMetadataCatalogFilter(*client_session, instr_mgr);
+    std::string upper_sql = boost::to_upper_copy(sql);
+    if (!client_session->catalog_access.empty() && metadata_filter.IsRestricted() &&
+        QueryTouchesRestrictedMetadataSource(upper_sql)) {
+      if (IsRestrictedMetadataQueryTooComplex(upper_sql)) {
+        return Status::Invalid(
+            "Access denied: Complex metadata queries are not supported for "
+            "catalog-restricted tokens.");
+      }
+      restricted_metadata_filter = metadata_filter;
+    }
+  }
+#endif
+
   // Prevent DETACH of instrumentation database (only relevant when enterprise is enabled)
 #ifdef GIZMOSQL_ENTERPRISE
   {
     // Get the instrumentation catalog name to also protect external catalogs (e.g., DuckLake)
-    std::string instr_catalog;
-    if (auto server = GetServer(*client_session)) {
-      if (auto mgr = server->GetInstrumentationManager()) {
-        instr_catalog = mgr->GetCatalog();
-      }
-    }
+    std::string instr_catalog = instr_mgr ? instr_mgr->GetCatalog() : "";
     if (IsDetachInstrumentationDb(sql, instr_catalog)) {
       GIZMOSQL_LOGKV_SESSION(WARNING, client_session, "Client attempted to DETACH instrumentation database",
                      {"kind", "sql"}, {"status", "rejected"},
                      {"statement_id", handle}, {"sql", logged_sql});
       std::string error_msg = "Cannot DETACH the instrumentation database";
       // Record the rejected DETACH attempt
-      if (auto server = GetServer(*client_session)) {
-        if (auto mgr = server->GetInstrumentationManager()) {
-          StatementInstrumentation(mgr, handle, client_session->session_id, logged_sql,
-                                   flight_method, is_internal, error_msg);
-        }
+      if (instr_mgr) {
+        StatementInstrumentation(instr_mgr, handle, client_session->session_id, logged_sql,
+                                 flight_method, is_internal, error_msg);
       }
       return Status::Invalid(error_msg);
     }
@@ -691,10 +784,6 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 #ifdef GIZMOSQL_ENTERPRISE
   if (gizmosql::enterprise::IsKillSessionCommand(sql, target_session_id)) {
     auto server = GetServer(*client_session);
-    std::shared_ptr<InstrumentationManager> instr_mgr;
-    if (server) {
-      instr_mgr = server->GetInstrumentationManager();
-    }
 
     auto kill_status = gizmosql::enterprise::HandleKillSession(
         client_session, target_session_id, server.get(), instr_mgr,
@@ -771,11 +860,6 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 #ifdef GIZMOSQL_ENTERPRISE
     // Check catalog-level access permissions (Enterprise feature)
     // These checks enforce per-catalog read/write permissions from JWT token claims
-    std::shared_ptr<InstrumentationManager> instr_mgr;
-    if (auto server = GetServer(*client_session)) {
-      instr_mgr = server->GetInstrumentationManager();
-    }
-
     // Check write access for all catalogs the statement will modify
     auto write_status = gizmosql::enterprise::CheckCatalogWriteAccess(
         client_session, stmt->data->properties.modified_databases,
@@ -817,6 +901,13 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
     // Check if this is the multiple statements error that can be resolved with direct execution
     if (error_message.find("Cannot prepare multiple statements at once") !=
         std::string::npos) {
+#ifdef GIZMOSQL_ENTERPRISE
+      if (restricted_metadata_filter.has_value()) {
+        return Status::Invalid(
+            "Access denied: Catalog-restricted metadata queries do not support "
+            "multi-statement execution.");
+      }
+#endif
       // Fallback to direct query execution for statements like PIVOT that get rewritten to multiple statements
       if (log_queries) {
         GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
@@ -832,12 +923,14 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
           client_session, handle, sql, log_level, log_queries, override_schema));
 
 #ifdef GIZMOSQL_ENTERPRISE
+      if (restricted_metadata_filter.has_value()) {
+        result->restrict_metadata_results_ = true;
+        result->metadata_catalog_filter_ = *restricted_metadata_filter;
+      }
       // Create statement instrumentation for direct execution
-      if (auto server = GetServer(*client_session)) {
-        if (auto mgr = server->GetInstrumentationManager()) {
-          result->instrumentation_ = std::make_unique<StatementInstrumentation>(
-              mgr, handle, client_session->session_id, logged_sql, flight_method, is_internal);
-        }
+      if (instr_mgr) {
+        result->instrumentation_ = std::make_unique<StatementInstrumentation>(
+            instr_mgr, handle, client_session->session_id, logged_sql, flight_method, is_internal);
       }
 #endif
 
@@ -874,12 +967,14 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
       client_session, handle, stmt, log_level, log_queries, override_schema));
 
 #ifdef GIZMOSQL_ENTERPRISE
+  if (restricted_metadata_filter.has_value()) {
+    result->restrict_metadata_results_ = true;
+    result->metadata_catalog_filter_ = *restricted_metadata_filter;
+  }
   // Create statement instrumentation for prepared statement
-  if (auto server = GetServer(*client_session)) {
-    if (auto mgr = server->GetInstrumentationManager()) {
-      result->instrumentation_ = std::make_unique<StatementInstrumentation>(
-          mgr, handle, client_session->session_id, logged_sql, flight_method, is_internal);
-    }
+  if (instr_mgr) {
+    result->instrumentation_ = std::make_unique<StatementInstrumentation>(
+        instr_mgr, handle, client_session->session_id, logged_sql, flight_method, is_internal);
   }
 #endif
 
@@ -1357,6 +1452,9 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> DuckDBStatement::FetchResult(
     duckdb::ArrowConverter::ToArrowArray(*data_chunk, &res_arr, res_options,
                                          extension_type_cast);
     ARROW_ASSIGN_OR_RAISE(record_batch, arrow::ImportRecordBatch(&res_arr, &res_schema));
+#ifdef GIZMOSQL_ENTERPRISE
+    ARROW_ASSIGN_OR_RAISE(record_batch, FilterRestrictedMetadataBatch(record_batch));
+#endif
 
     GIZMOSQL_LOGKV_SESSION(DEBUG, client_session_, "Client RecordBatch Fetch",
                    {"kind", "fetch"}, {"status", "success"},
@@ -1450,6 +1548,122 @@ arrow::Result<std::shared_ptr<arrow::Schema>> DuckDBStatement::GetSchema() {
   return cached_schema_;
 }
 
+#ifdef GIZMOSQL_ENTERPRISE
+arrow::Status DuckDBStatement::ValidateRestrictedMetadataSchema(
+    const std::shared_ptr<arrow::Schema>& schema) const {
+  if (!restrict_metadata_results_ || !metadata_catalog_filter_.has_value() || !schema) {
+    return arrow::Status::OK();
+  }
+
+  static const std::vector<std::string> kCatalogColumns = {
+      "catalog_name", "table_catalog", "database_name", "pk_catalog_name", "fk_catalog_name"};
+
+  for (const auto& column_name : kCatalogColumns) {
+    if (schema->GetFieldIndex(column_name) != -1) {
+      return arrow::Status::OK();
+    }
+  }
+
+  return arrow::Status::Invalid(
+      "Access denied: Metadata queries for catalog-restricted tokens must include "
+      "catalog columns in the result.");
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> DuckDBStatement::FilterRestrictedMetadataBatch(
+    const std::shared_ptr<arrow::RecordBatch>& batch) const {
+  if (!restrict_metadata_results_ || !metadata_catalog_filter_.has_value() || !batch) {
+    return batch;
+  }
+
+  static const std::vector<std::string> kCatalogColumns = {
+      "catalog_name", "table_catalog", "database_name", "pk_catalog_name", "fk_catalog_name"};
+
+  std::vector<int> catalog_column_indices;
+  for (const auto& column_name : kCatalogColumns) {
+    int column_index = batch->schema()->GetFieldIndex(column_name);
+    if (column_index != -1) {
+      catalog_column_indices.push_back(column_index);
+    }
+  }
+
+  if (catalog_column_indices.empty()) {
+    return arrow::Status::Invalid(
+        "Access denied: Metadata queries for catalog-restricted tokens must include "
+        "catalog columns in the result.");
+  }
+
+  std::vector<bool> keep_rows(batch->num_rows(), true);
+  int64_t kept_rows = 0;
+
+  for (int64_t row = 0; row < batch->num_rows(); ++row) {
+    bool keep_row = true;
+    for (int column_index : catalog_column_indices) {
+      ARROW_ASSIGN_OR_RAISE(auto scalar, batch->column(column_index)->GetScalar(row));
+      if (!scalar->is_valid) {
+        keep_row = false;
+        break;
+      }
+
+      std::string catalog_name;
+      if (auto string_scalar = std::dynamic_pointer_cast<arrow::StringScalar>(scalar)) {
+        catalog_name = std::string(string_scalar->view());
+      } else if (auto large_string_scalar =
+                     std::dynamic_pointer_cast<arrow::LargeStringScalar>(scalar)) {
+        catalog_name = std::string(large_string_scalar->view());
+      } else {
+        return arrow::Status::Invalid(
+            "Access denied: Metadata catalog columns must be strings for "
+            "catalog-restricted tokens.");
+      }
+
+      if (!metadata_catalog_filter_->Allows(catalog_name)) {
+        keep_row = false;
+        break;
+      }
+    }
+
+    keep_rows[row] = keep_row;
+    if (keep_row) {
+      kept_rows++;
+    }
+  }
+
+  if (kept_rows == batch->num_rows()) {
+    return batch;
+  }
+
+  std::vector<std::unique_ptr<arrow::ArrayBuilder>> builders;
+  builders.reserve(batch->num_columns());
+  for (const auto& field : batch->schema()->fields()) {
+    std::unique_ptr<arrow::ArrayBuilder> builder;
+    ARROW_RETURN_NOT_OK(arrow::MakeBuilder(arrow::default_memory_pool(), field->type(),
+                                           &builder));
+    builders.push_back(std::move(builder));
+  }
+
+  for (int64_t row = 0; row < batch->num_rows(); ++row) {
+    if (!keep_rows[row]) {
+      continue;
+    }
+
+    for (int column_index = 0; column_index < batch->num_columns(); ++column_index) {
+      ARROW_ASSIGN_OR_RAISE(auto scalar, batch->column(column_index)->GetScalar(row));
+      ARROW_RETURN_NOT_OK(builders[column_index]->AppendScalar(*scalar));
+    }
+  }
+
+  std::vector<std::shared_ptr<arrow::Array>> arrays;
+  arrays.reserve(batch->num_columns());
+  for (auto& builder : builders) {
+    std::shared_ptr<arrow::Array> array;
+    ARROW_RETURN_NOT_OK(builder->Finish(&array));
+    arrays.push_back(std::move(array));
+  }
+
+  return arrow::RecordBatch::Make(batch->schema(), kept_rows, arrays);
+}
+#endif
+
 long DuckDBStatement::GetLastExecutionDurationMs() const {
   return std::chrono::duration_cast<std::chrono::milliseconds>(end_time_ - start_time_)
       .count();
@@ -1483,7 +1697,10 @@ arrow::Result<std::shared_ptr<arrow::Schema>> DuckDBStatement::ComputeSchema() {
     duckdb::ArrowConverter::ToArrowSchema(&arrow_schema, query_result_->types,
                                           query_result_->names, client_properties);
 
-    auto return_value = arrow::ImportSchema(&arrow_schema);
+    ARROW_ASSIGN_OR_RAISE(auto return_value, arrow::ImportSchema(&arrow_schema));
+#ifdef GIZMOSQL_ENTERPRISE
+    ARROW_RETURN_NOT_OK(ValidateRestrictedMetadataSchema(return_value));
+#endif
     status = "success";
     return return_value;
   }
@@ -1497,7 +1714,10 @@ arrow::Result<std::shared_ptr<arrow::Schema>> DuckDBStatement::ComputeSchema() {
   ArrowSchema arrow_schema;
   duckdb::ArrowConverter::ToArrowSchema(&arrow_schema, types, names, client_properties);
 
-  auto return_value = arrow::ImportSchema(&arrow_schema);
+  ARROW_ASSIGN_OR_RAISE(auto return_value, arrow::ImportSchema(&arrow_schema));
+#ifdef GIZMOSQL_ENTERPRISE
+  ARROW_RETURN_NOT_OK(ValidateRestrictedMetadataSchema(return_value));
+#endif
   status = "success";
   return return_value;
 }

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -239,27 +239,6 @@ std::string BuildRestrictedShowDatabasesSql(
   query << " ORDER BY database_name";
   return query.str();
 }
-
-std::string BuildRestrictedShowAllTablesSql(
-    const gizmosql::enterprise::MetadataCatalogFilter& metadata_filter) {
-  std::stringstream query;
-  query << "SELECT t.database_name AS database, "
-           "t.schema_name AS schema, "
-           "t.table_name AS name, "
-           "LIST(c.column_name ORDER BY c.column_index) AS column_names, "
-           "LIST(c.data_type ORDER BY c.column_index) AS column_types, "
-           "t.temporary "
-           "FROM duckdb_tables() AS t "
-           "LEFT JOIN duckdb_columns() AS c "
-           "ON t.database_name = c.database_name "
-           "AND t.schema_name = c.schema_name "
-           "AND t.table_name = c.table_name "
-           "WHERE 1 = 1";
-  query << BuildInlineMetadataCatalogFilterSql(metadata_filter, "t.database_name");
-  query << " GROUP BY t.database_name, t.schema_name, t.table_name, t.temporary "
-           "ORDER BY database, schema, name";
-  return query.str();
-}
 #endif
 
 bool CatalogExistsOnConnection(const std::shared_ptr<duckdb::Connection>& connection,
@@ -841,7 +820,9 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
       if (IsShowDatabasesQuery(sql)) {
         effective_sql = BuildRestrictedShowDatabasesSql(metadata_filter);
       } else if (IsShowAllTablesQuery(sql)) {
-        effective_sql = BuildRestrictedShowAllTablesSql(metadata_filter);
+        return Status::Invalid(
+            "Access denied: SHOW ALL TABLES is not allowed for catalog-restricted "
+            "tokens. Use SHOW TABLES after selecting an allowed catalog.");
       } else if (QueryTouchesRestrictedMetadataSource(upper_sql)) {
         if (IsRestrictedMetadataQueryTooComplex(upper_sql)) {
           return Status::Invalid(

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -172,6 +172,96 @@ std::optional<std::string> TryExtractUseCatalogName(const std::string& sql) {
   return first_identifier;
 }
 
+#ifdef GIZMOSQL_ENTERPRISE
+std::string QuoteSqlStringLiteral(const std::string& value) {
+  std::string quoted = "'";
+  for (char ch : value) {
+    if (ch == '\'') {
+      quoted += "''";
+    } else {
+      quoted += ch;
+    }
+  }
+  quoted += "'";
+  return quoted;
+}
+
+std::string BuildInlineMetadataCatalogFilterSql(
+    const gizmosql::enterprise::MetadataCatalogFilter& filter,
+    const std::string& column_name) {
+  if (!filter.IsRestricted()) {
+    return "";
+  }
+
+  if (filter.mode == gizmosql::enterprise::MetadataCatalogFilterMode::kAllowOnly &&
+      filter.catalogs.empty()) {
+    return " AND 1 = 0";
+  }
+
+  if (filter.catalogs.empty()) {
+    return "";
+  }
+
+  std::stringstream predicate;
+  predicate << " AND " << column_name << " "
+            << (filter.mode == gizmosql::enterprise::MetadataCatalogFilterMode::kAllowOnly
+                    ? "IN ("
+                    : "NOT IN (");
+
+  for (size_t i = 0; i < filter.catalogs.size(); ++i) {
+    if (i > 0) {
+      predicate << ", ";
+    }
+    predicate << QuoteSqlStringLiteral(filter.catalogs[i]);
+  }
+
+  predicate << ")";
+  return predicate.str();
+}
+
+bool IsShowDatabasesQuery(const std::string& sql) {
+  static const std::regex show_databases_pattern(
+      R"(^\s*SHOW\s+DATABASES\s*;?\s*$)", std::regex_constants::icase);
+  return std::regex_match(sql, show_databases_pattern);
+}
+
+bool IsShowAllTablesQuery(const std::string& sql) {
+  static const std::regex show_all_tables_pattern(
+      R"(^\s*SHOW\s+ALL\s+TABLES\s*;?\s*$)", std::regex_constants::icase);
+  return std::regex_match(sql, show_all_tables_pattern);
+}
+
+std::string BuildRestrictedShowDatabasesSql(
+    const gizmosql::enterprise::MetadataCatalogFilter& metadata_filter) {
+  std::stringstream query;
+  query << "SELECT database_name FROM duckdb_databases() WHERE 1 = 1";
+  query << BuildInlineMetadataCatalogFilterSql(metadata_filter, "database_name");
+  query << " ORDER BY database_name";
+  return query.str();
+}
+
+std::string BuildRestrictedShowAllTablesSql(
+    const gizmosql::enterprise::MetadataCatalogFilter& metadata_filter) {
+  std::stringstream query;
+  query << "SELECT t.database_name AS database, "
+           "t.schema_name AS schema, "
+           "t.table_name AS name, "
+           "LIST(c.column_name ORDER BY c.column_index) AS column_names, "
+           "LIST(c.data_type ORDER BY c.column_index) AS column_types, "
+           "t.temporary "
+           "FROM duckdb_tables() AS t "
+           "LEFT JOIN duckdb_columns() AS c "
+           "ON t.database_name = c.database_name "
+           "AND t.schema_name = c.schema_name "
+           "AND t.table_name = c.table_name "
+           "WHERE 1 = 1";
+  query << BuildInlineMetadataCatalogFilterSql(metadata_filter, "t.database_name");
+  query << " GROUP BY t.database_name, t.schema_name, t.table_name, t.temporary "
+           "ORDER BY database, schema, name";
+  return query.str();
+}
+#endif
+
 bool CatalogExistsOnConnection(const std::shared_ptr<duckdb::Connection>& connection,
                                const std::string& catalog_name) {
   auto stmt = connection->Prepare(
@@ -746,15 +836,20 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 
     auto metadata_filter =
         gizmosql::enterprise::GetMetadataCatalogFilter(*client_session, instr_mgr);
-    std::string upper_sql = boost::to_upper_copy(sql);
-    if (!client_session->catalog_access.empty() && metadata_filter.IsRestricted() &&
-        QueryTouchesRestrictedMetadataSource(upper_sql)) {
-      if (IsRestrictedMetadataQueryTooComplex(upper_sql)) {
-        return Status::Invalid(
-            "Access denied: Complex metadata queries are not supported for "
-            "catalog-restricted tokens.");
+    if (!client_session->catalog_access.empty() && metadata_filter.IsRestricted()) {
+      std::string upper_sql = boost::to_upper_copy(sql);
+      if (IsShowDatabasesQuery(sql)) {
+        effective_sql = BuildRestrictedShowDatabasesSql(metadata_filter);
+      } else if (IsShowAllTablesQuery(sql)) {
+        effective_sql = BuildRestrictedShowAllTablesSql(metadata_filter);
+      } else if (QueryTouchesRestrictedMetadataSource(upper_sql)) {
+        if (IsRestrictedMetadataQueryTooComplex(upper_sql)) {
+          return Status::Invalid(
+              "Access denied: Complex metadata queries are not supported for "
+              "catalog-restricted tokens.");
+        }
+        restricted_metadata_filter = metadata_filter;
       }
-      restricted_metadata_filter = metadata_filter;
     }
   }
 #endif

--- a/src/duckdb/duckdb_statement.h
+++ b/src/duckdb/duckdb_statement.h
@@ -30,6 +30,9 @@
 #include "session_context.h"
 #include <chrono>
 #include <arrow/record_batch.h>
+#ifdef GIZMOSQL_ENTERPRISE
+#include "enterprise/catalog_permissions/catalog_permissions_handler.h"
+#endif
 
 using Clock = std::chrono::steady_clock;
 
@@ -148,5 +151,15 @@ class DuckDBStatement {
   arrow::Result<int32_t> GetQueryTimeout() const;
 
   arrow::Result<arrow::util::ArrowLogLevel> GetLogLevel() const;
+
+#ifdef GIZMOSQL_ENTERPRISE
+  arrow::Status ValidateRestrictedMetadataSchema(
+      const std::shared_ptr<arrow::Schema>& schema) const;
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> FilterRestrictedMetadataBatch(
+      const std::shared_ptr<arrow::RecordBatch>& batch) const;
+
+  std::optional<gizmosql::enterprise::MetadataCatalogFilter> metadata_catalog_filter_;
+  bool restrict_metadata_results_ = false;
+#endif
 };
 }  // namespace gizmosql::ddb

--- a/src/enterprise/catalog_permissions/catalog_permissions_handler.cpp
+++ b/src/enterprise/catalog_permissions/catalog_permissions_handler.cpp
@@ -4,6 +4,10 @@
 
 #include "catalog_permissions_handler.h"
 
+#include <algorithm>
+#include <sstream>
+#include <unordered_map>
+
 #include "gizmosql_logging.h"
 #include "session_context.h"
 #include "enterprise/enterprise_features.h"
@@ -11,6 +15,54 @@
 #include "instrumentation/instrumentation_records.h"
 
 namespace gizmosql::enterprise {
+
+namespace {
+
+void AddCatalogIfMissing(std::vector<std::string>& catalogs, const std::string& catalog_name) {
+  if (std::find(catalogs.begin(), catalogs.end(), catalog_name) == catalogs.end()) {
+    catalogs.push_back(catalog_name);
+  }
+}
+
+void RemoveCatalogIfPresent(std::vector<std::string>& catalogs, const std::string& catalog_name) {
+  catalogs.erase(std::remove(catalogs.begin(), catalogs.end(), catalog_name), catalogs.end());
+}
+
+std::string GetReadAccessDeniedMessage(
+    const ClientSession& client_session,
+    const std::string& catalog_name,
+    const std::shared_ptr<gizmosql::ddb::InstrumentationManager>& instrumentation_manager) {
+  if (instrumentation_manager && catalog_name == instrumentation_manager->GetCatalog() &&
+      client_session.role != "admin") {
+    return "Access denied: Only administrators can read the instrumentation catalog '" +
+           catalog_name + "'.";
+  }
+
+  return "Access denied: You do not have read access to catalog '" + catalog_name + "'.";
+}
+
+}  // namespace
+
+bool MetadataCatalogFilter::IsRestricted() const {
+  return mode == MetadataCatalogFilterMode::kAllowOnly ||
+         (mode == MetadataCatalogFilterMode::kAllowAllExcept && !catalogs.empty());
+}
+
+bool MetadataCatalogFilter::Allows(const std::string& catalog_name) const {
+  const bool contains =
+      std::find(catalogs.begin(), catalogs.end(), catalog_name) != catalogs.end();
+
+  switch (mode) {
+    case MetadataCatalogFilterMode::kAllowAll:
+      return true;
+    case MetadataCatalogFilterMode::kAllowOnly:
+      return contains;
+    case MetadataCatalogFilterMode::kAllowAllExcept:
+      return !contains;
+  }
+
+  return true;
+}
 
 CatalogAccessLevel GetCatalogAccess(
     const std::string& catalog_name,
@@ -58,6 +110,122 @@ bool HasWriteAccess(const ClientSession& client_session, const std::string& cata
   auto access = GetCatalogAccess(catalog_name, client_session.role, client_session.catalog_access,
                                  instrumentation_manager);
   return access >= CatalogAccessLevel::kWrite;
+}
+
+MetadataCatalogFilter GetMetadataCatalogFilter(
+    const ClientSession& client_session,
+    const std::shared_ptr<gizmosql::ddb::InstrumentationManager>& instrumentation_manager) {
+  MetadataCatalogFilter filter;
+
+  const bool catalog_permissions_enabled =
+      EnterpriseFeatures::Instance().IsCatalogPermissionsAvailable();
+
+  if (!catalog_permissions_enabled || client_session.catalog_access.empty()) {
+    filter.mode = MetadataCatalogFilterMode::kAllowAll;
+  } else {
+    std::unordered_map<std::string, CatalogAccessLevel> explicit_rules;
+    bool wildcard_seen = false;
+    CatalogAccessLevel wildcard_access = CatalogAccessLevel::kNone;
+
+    for (const auto& rule : client_session.catalog_access) {
+      if (rule.catalog == "*") {
+        wildcard_seen = true;
+        wildcard_access = rule.access;
+        break;
+      }
+
+      explicit_rules.emplace(rule.catalog, rule.access);
+    }
+
+    if (!wildcard_seen || wildcard_access < CatalogAccessLevel::kRead) {
+      filter.mode = MetadataCatalogFilterMode::kAllowOnly;
+      for (const auto& [catalog_name, access] : explicit_rules) {
+        if (access >= CatalogAccessLevel::kRead) {
+          filter.catalogs.push_back(catalog_name);
+        }
+      }
+    } else {
+      filter.mode = MetadataCatalogFilterMode::kAllowAllExcept;
+      for (const auto& [catalog_name, access] : explicit_rules) {
+        if (access < CatalogAccessLevel::kRead) {
+          filter.catalogs.push_back(catalog_name);
+        }
+      }
+      if (filter.catalogs.empty()) {
+        filter.mode = MetadataCatalogFilterMode::kAllowAll;
+      }
+    }
+  }
+
+  if (instrumentation_manager) {
+    const auto& instrumentation_catalog = instrumentation_manager->GetCatalog();
+    if (client_session.role == "admin") {
+      if (filter.mode == MetadataCatalogFilterMode::kAllowOnly) {
+        AddCatalogIfMissing(filter.catalogs, instrumentation_catalog);
+      } else if (filter.mode == MetadataCatalogFilterMode::kAllowAllExcept) {
+        RemoveCatalogIfPresent(filter.catalogs, instrumentation_catalog);
+        if (filter.catalogs.empty()) {
+          filter.mode = MetadataCatalogFilterMode::kAllowAll;
+        }
+      }
+    } else {
+      if (filter.mode == MetadataCatalogFilterMode::kAllowAll) {
+        filter.mode = MetadataCatalogFilterMode::kAllowAllExcept;
+        filter.catalogs.push_back(instrumentation_catalog);
+      } else if (filter.mode == MetadataCatalogFilterMode::kAllowOnly) {
+        RemoveCatalogIfPresent(filter.catalogs, instrumentation_catalog);
+      } else {
+        AddCatalogIfMissing(filter.catalogs, instrumentation_catalog);
+      }
+    }
+  }
+
+  std::sort(filter.catalogs.begin(), filter.catalogs.end());
+  return filter;
+}
+
+std::string BuildMetadataCatalogFilterSql(
+    const MetadataCatalogFilter& filter,
+    const std::string& column_name,
+    duckdb::vector<duckdb::Value>& bind_parameters) {
+  if (!filter.IsRestricted()) {
+    return "";
+  }
+
+  if (filter.mode == MetadataCatalogFilterMode::kAllowOnly && filter.catalogs.empty()) {
+    return " AND 1 = 0";
+  }
+
+  if (filter.catalogs.empty()) {
+    return "";
+  }
+
+  std::stringstream predicate;
+  predicate << " AND " << column_name << " "
+            << (filter.mode == MetadataCatalogFilterMode::kAllowOnly ? "IN (" : "NOT IN (");
+
+  for (size_t i = 0; i < filter.catalogs.size(); ++i) {
+    if (i > 0) {
+      predicate << ", ";
+    }
+    predicate << "?";
+    bind_parameters.emplace_back(filter.catalogs[i]);
+  }
+
+  predicate << ")";
+  return predicate.str();
+}
+
+arrow::Status EnsureCatalogReadAccess(
+    const ClientSession& client_session,
+    const std::string& catalog_name,
+    const std::shared_ptr<gizmosql::ddb::InstrumentationManager>& instrumentation_manager) {
+  if (HasReadAccess(client_session, catalog_name, instrumentation_manager)) {
+    return arrow::Status::OK();
+  }
+
+  return arrow::Status::Invalid(
+      GetReadAccessDeniedMessage(client_session, catalog_name, instrumentation_manager));
 }
 
 arrow::Status CheckCatalogWriteAccess(

--- a/src/enterprise/catalog_permissions/catalog_permissions_handler.h
+++ b/src/enterprise/catalog_permissions/catalog_permissions_handler.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <arrow/status.h>
@@ -22,6 +23,20 @@ class InstrumentationManager;
 }
 
 namespace gizmosql::enterprise {
+
+enum class MetadataCatalogFilterMode {
+  kAllowAll = 0,
+  kAllowOnly = 1,
+  kAllowAllExcept = 2,
+};
+
+struct MetadataCatalogFilter {
+  MetadataCatalogFilterMode mode = MetadataCatalogFilterMode::kAllowAll;
+  std::vector<std::string> catalogs;
+
+  bool IsRestricted() const;
+  bool Allows(const std::string& catalog_name) const;
+};
 
 /// Get the catalog access level for a given catalog name.
 /// This evaluates the catalog_access rules from the session's JWT token.
@@ -53,6 +68,26 @@ bool HasReadAccess(const ClientSession& client_session, const std::string& catal
 /// @return true if write access is granted
 bool HasWriteAccess(const ClientSession& client_session, const std::string& catalog_name,
                     const std::shared_ptr<gizmosql::ddb::InstrumentationManager>& instrumentation_manager = nullptr);
+
+/// Build a metadata-visibility filter from the session's catalog rules.
+/// This is used to scope catalog/schema/table metadata enumeration for
+/// catalog-restricted tokens.
+MetadataCatalogFilter GetMetadataCatalogFilter(
+    const ClientSession& client_session,
+    const std::shared_ptr<gizmosql::ddb::InstrumentationManager>& instrumentation_manager = nullptr);
+
+/// Build a SQL predicate fragment for a metadata catalog column.
+/// Returns an empty string if no filtering is required.
+std::string BuildMetadataCatalogFilterSql(
+    const MetadataCatalogFilter& filter,
+    const std::string& column_name,
+    duckdb::vector<duckdb::Value>& bind_parameters);
+
+/// Return Invalid when the session cannot read the given catalog.
+arrow::Status EnsureCatalogReadAccess(
+    const ClientSession& client_session,
+    const std::string& catalog_name,
+    const std::shared_ptr<gizmosql::ddb::InstrumentationManager>& instrumentation_manager = nullptr);
 
 /// Check catalog-level write access for all databases a statement will modify.
 /// This is an enterprise feature that requires a valid license with catalog_permissions.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_authentication.cpp
         integration/test_bulk_ingest.cpp
         integration/test_catalog_access.cpp
+        integration/test_catalog_metadata_restrictions.cpp
         integration/test_catalog_permissions_enterprise.cpp
         integration/test_cross_instance_tokens.cpp
         integration/test_health_check.cpp

--- a/tests/integration/test_catalog_metadata_restrictions.cpp
+++ b/tests/integration/test_catalog_metadata_restrictions.cpp
@@ -340,6 +340,39 @@ TEST_F(CatalogMetadataRestrictionFixture, ShowAllTablesIsDenied) {
             std::string::npos);
 }
 
+TEST_F(CatalogMetadataRestrictionFixture, DuckDBMetadataFunctionsAreDenied) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  const std::vector<std::pair<std::string, std::string>> queries = {
+      {"duckdb_databases()",
+       "SELECT database_name FROM duckdb_databases() ORDER BY database_name"},
+      {"duckdb_tables()",
+       "SELECT database_name, schema_name, table_name "
+       "FROM duckdb_tables() ORDER BY database_name, table_name"},
+      {"duckdb_columns()",
+       "SELECT database_name, schema_name, table_name, column_name "
+       "FROM duckdb_columns() ORDER BY database_name, table_name, column_name"},
+      {"duckdb_schemas()",
+       "SELECT database_name, schema_name FROM duckdb_schemas() "
+       "ORDER BY database_name, schema_name"},
+      {"duckdb_views()",
+       "SELECT database_name, schema_name, view_name "
+       "FROM duckdb_views() ORDER BY database_name, view_name"},
+  };
+
+  for (const auto& [function_name, query] : queries) {
+    auto result = client->Execute(call_options, query);
+    ASSERT_FALSE(result.ok()) << "Expected " << function_name << " to be denied";
+    ASSERT_NE(result.status().ToString().find(function_name), std::string::npos)
+        << result.status().ToString();
+  }
+}
+
 TEST_F(CatalogMetadataRestrictionFixture, InformationSchemaTablesShowsOnlyAllowedCatalog) {
   SKIP_WITHOUT_LICENSE();
   ASSERT_TRUE(IsServerReady()) << "Server not ready";

--- a/tests/integration/test_catalog_metadata_restrictions.cpp
+++ b/tests/integration/test_catalog_metadata_restrictions.cpp
@@ -326,7 +326,7 @@ TEST_F(CatalogMetadataRestrictionFixture, ShowDatabasesShowsOnlyAllowedCatalog) 
   EXPECT_EQ(catalogs[0], kAllowedCatalog);
 }
 
-TEST_F(CatalogMetadataRestrictionFixture, ShowAllTablesShowsOnlyAllowedCatalog) {
+TEST_F(CatalogMetadataRestrictionFixture, ShowAllTablesIsDenied) {
   SKIP_WITHOUT_LICENSE();
   ASSERT_TRUE(IsServerReady()) << "Server not ready";
 
@@ -334,14 +334,10 @@ TEST_F(CatalogMetadataRestrictionFixture, ShowAllTablesShowsOnlyAllowedCatalog) 
   auto call_options = GetCallOptionsWithToken(token);
   ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
 
-  ASSERT_ARROW_OK_AND_ASSIGN(auto table,
-                             ExecuteToTable(*client, call_options, "SHOW ALL TABLES"));
-
-  auto catalogs = GetStringColumnValues(table, "database");
-  ASSERT_FALSE(catalogs.empty());
-  for (const auto& catalog : catalogs) {
-    EXPECT_EQ(catalog, kAllowedCatalog);
-  }
+  auto result = client->Execute(call_options, "SHOW ALL TABLES");
+  ASSERT_FALSE(result.ok());
+  ASSERT_NE(result.status().ToString().find("SHOW ALL TABLES is not allowed"),
+            std::string::npos);
 }
 
 TEST_F(CatalogMetadataRestrictionFixture, InformationSchemaTablesShowsOnlyAllowedCatalog) {

--- a/tests/integration/test_catalog_metadata_restrictions.cpp
+++ b/tests/integration/test_catalog_metadata_restrictions.cpp
@@ -310,6 +310,40 @@ TEST_F(CatalogMetadataRestrictionFixture, UseForbiddenCatalogIsDenied) {
   ASSERT_NE(result.status().ToString().find("Access denied"), std::string::npos);
 }
 
+TEST_F(CatalogMetadataRestrictionFixture, ShowDatabasesShowsOnlyAllowedCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  ASSERT_ARROW_OK_AND_ASSIGN(auto table,
+                             ExecuteToTable(*client, call_options, "SHOW DATABASES"));
+
+  auto catalogs = GetStringColumnValues(table, "database_name");
+  ASSERT_EQ(catalogs.size(), 1);
+  EXPECT_EQ(catalogs[0], kAllowedCatalog);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, ShowAllTablesShowsOnlyAllowedCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  ASSERT_ARROW_OK_AND_ASSIGN(auto table,
+                             ExecuteToTable(*client, call_options, "SHOW ALL TABLES"));
+
+  auto catalogs = GetStringColumnValues(table, "database");
+  ASSERT_FALSE(catalogs.empty());
+  for (const auto& catalog : catalogs) {
+    EXPECT_EQ(catalog, kAllowedCatalog);
+  }
+}
+
 TEST_F(CatalogMetadataRestrictionFixture, InformationSchemaTablesShowsOnlyAllowedCatalog) {
   SKIP_WITHOUT_LICENSE();
   ASSERT_TRUE(IsServerReady()) << "Server not ready";

--- a/tests/integration/test_catalog_metadata_restrictions.cpp
+++ b/tests/integration/test_catalog_metadata_restrictions.cpp
@@ -1,0 +1,370 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <jwt-cpp/jwt.h>
+#include <picojson.h>
+
+#include "arrow/api.h"
+#include "arrow/flight/sql/client.h"
+#include "arrow/flight/sql/types.h"
+#include "arrow/testing/gtest_util.h"
+#include "test_server_fixture.h"
+#include "test_util.h"
+
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+bool HasEnterpriseLicense() {
+  const char* license_file = std::getenv("GIZMOSQL_LICENSE_KEY_FILE");
+  return license_file != nullptr && license_file[0] != '\0';
+}
+
+#define SKIP_WITHOUT_LICENSE()                                                        \
+  if (!HasEnterpriseLicense()) {                                                      \
+    GTEST_SKIP() << "Catalog permissions is an enterprise feature. "                  \
+                 << "Set GIZMOSQL_LICENSE_KEY_FILE environment variable.";            \
+  }
+
+const std::string kTestSecretKey = "test_secret_key_for_testing";
+const std::string kServerJWTIssuer = "gizmosql";
+const std::string kAllowedCatalog = "allowed_catalog";
+const std::string kBlockedCatalog = "blocked_catalog";
+
+std::string GenerateTestUUID() {
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<> dis(0, 15);
+  static std::uniform_int_distribution<> dis2(8, 11);
+
+  std::stringstream ss;
+  ss << std::hex;
+  for (int i = 0; i < 8; i++) ss << dis(gen);
+  ss << "-";
+  for (int i = 0; i < 4; i++) ss << dis(gen);
+  ss << "-4";
+  for (int i = 0; i < 3; i++) ss << dis(gen);
+  ss << "-";
+  ss << dis2(gen);
+  for (int i = 0; i < 3; i++) ss << dis(gen);
+  ss << "-";
+  for (int i = 0; i < 12; i++) ss << dis(gen);
+  return ss.str();
+}
+
+std::string CreateTestJWT(const std::string& username, const std::string& role,
+                          const std::string& catalog_access_json) {
+  auto builder = jwt::create()
+                     .set_issuer(kServerJWTIssuer)
+                     .set_type("JWT")
+                     .set_id("test-" + GenerateTestUUID())
+                     .set_issued_at(std::chrono::system_clock::now())
+                     .set_expires_at(std::chrono::system_clock::now() + std::chrono::hours{24})
+                     .set_payload_claim("sub", jwt::claim(username))
+                     .set_payload_claim("role", jwt::claim(role))
+                     .set_payload_claim("auth_method", jwt::claim(std::string("TestToken")))
+                     .set_payload_claim("session_id", jwt::claim(GenerateTestUUID()));
+
+  picojson::value v;
+  std::string err = picojson::parse(v, catalog_access_json);
+  if (err.empty()) {
+    builder = builder.set_payload_claim("catalog_access", jwt::claim(v));
+  }
+
+  return builder.sign(jwt::algorithm::hs256{kTestSecretKey});
+}
+
+arrow::Result<std::shared_ptr<arrow::Table>> CollectResults(
+    FlightSqlClient& client, const arrow::flight::FlightCallOptions& call_options,
+    const std::unique_ptr<arrow::flight::FlightInfo>& info) {
+  std::vector<std::shared_ptr<arrow::RecordBatch>> all_batches;
+  std::shared_ptr<arrow::Schema> schema;
+
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto stream, client.DoGet(call_options, endpoint.ticket));
+    ARROW_ASSIGN_OR_RAISE(auto stream_schema, stream->GetSchema());
+    if (!schema) {
+      schema = stream_schema;
+    }
+
+    while (true) {
+      ARROW_ASSIGN_OR_RAISE(auto chunk, stream->Next());
+      if (chunk.data == nullptr) {
+        break;
+      }
+      all_batches.push_back(chunk.data);
+    }
+  }
+
+  if (!schema) {
+    return arrow::Status::Invalid("No schema returned from query");
+  }
+
+  if (all_batches.empty()) {
+    return arrow::Table::MakeEmpty(schema);
+  }
+
+  return arrow::Table::FromRecordBatches(schema, all_batches);
+}
+
+arrow::Status ExecuteAndConsume(FlightSqlClient& client,
+                                const arrow::flight::FlightCallOptions& call_options,
+                                const std::string& query) {
+  ARROW_ASSIGN_OR_RAISE(auto info, client.Execute(call_options, query));
+  ARROW_RETURN_NOT_OK(CollectResults(client, call_options, info).status());
+  return arrow::Status::OK();
+}
+
+arrow::Result<std::shared_ptr<arrow::Table>> ExecuteToTable(
+    FlightSqlClient& client, const arrow::flight::FlightCallOptions& call_options,
+    const std::string& query) {
+  ARROW_ASSIGN_OR_RAISE(auto info, client.Execute(call_options, query));
+  return CollectResults(client, call_options, info);
+}
+
+std::vector<std::string> GetStringColumnValues(const std::shared_ptr<arrow::Table>& table,
+                                               const std::string& column_name) {
+  std::vector<std::string> values;
+  auto column = table->GetColumnByName(column_name);
+  if (!column) {
+    return values;
+  }
+
+  for (const auto& chunk : column->chunks()) {
+    if (chunk->type_id() == arrow::Type::STRING) {
+      auto string_array = std::static_pointer_cast<arrow::StringArray>(chunk);
+      for (int64_t i = 0; i < string_array->length(); ++i) {
+        if (!string_array->IsNull(i)) {
+          values.emplace_back(string_array->GetString(i));
+        }
+      }
+    } else if (chunk->type_id() == arrow::Type::LARGE_STRING) {
+      auto string_array = std::static_pointer_cast<arrow::LargeStringArray>(chunk);
+      for (int64_t i = 0; i < string_array->length(); ++i) {
+        if (!string_array->IsNull(i)) {
+          values.emplace_back(string_array->GetString(i));
+        }
+      }
+    }
+  }
+
+  return values;
+}
+
+class CatalogMetadataRestrictionFixture
+    : public gizmosql::testing::ServerTestFixture<CatalogMetadataRestrictionFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "catalog_metadata_restrictions_test.db",
+        .port = 31365,
+        .health_port = 31366,
+        .username = "tester",
+        .password = "tester",
+        .init_sql_commands =
+            "ATTACH ':memory:' AS allowed_catalog;"
+            "ATTACH ':memory:' AS blocked_catalog;"
+            "CREATE SCHEMA allowed_catalog.analytics;"
+            "CREATE SCHEMA blocked_catalog.analytics;"
+            "CREATE TABLE allowed_catalog.main.allowed_table (id INTEGER);"
+            "CREATE TABLE allowed_catalog.analytics.allowed_metrics (id INTEGER);"
+            "CREATE TABLE blocked_catalog.main.blocked_table (id INTEGER);"
+            "CREATE TABLE blocked_catalog.analytics.blocked_metrics (id INTEGER);",
+    };
+  }
+
+ protected:
+  arrow::Result<std::unique_ptr<FlightSqlClient>> CreateClientWithToken(
+      const std::string& token) {
+    arrow::flight::FlightClientOptions options;
+    ARROW_ASSIGN_OR_RAISE(auto location,
+                          arrow::flight::Location::ForGrpcTcp("localhost", GetPort()));
+    ARROW_ASSIGN_OR_RAISE(auto client,
+                          arrow::flight::FlightClient::Connect(location, options));
+    return std::make_unique<FlightSqlClient>(std::move(client));
+  }
+
+  arrow::flight::FlightCallOptions GetCallOptionsWithToken(const std::string& token) {
+    arrow::flight::FlightCallOptions call_options;
+    call_options.headers.push_back({"authorization", "Bearer " + token});
+    return call_options;
+  }
+
+  std::string CreateRestrictedToken() {
+    return CreateTestJWT("metadata_user", "user",
+                         R"([{"catalog": "allowed_catalog", "access": "read"}])");
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<CatalogMetadataRestrictionFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<CatalogMetadataRestrictionFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<CatalogMetadataRestrictionFixture>::server_ready_{
+        false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<CatalogMetadataRestrictionFixture>::config_{};
+
+TEST_F(CatalogMetadataRestrictionFixture, GetCatalogsReturnsOnlyAllowedCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  ASSERT_ARROW_OK_AND_ASSIGN(auto info, client->GetCatalogs(call_options));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto table, CollectResults(*client, call_options, info));
+
+  auto catalogs = GetStringColumnValues(table, "catalog_name");
+  ASSERT_EQ(catalogs.size(), 1);
+  EXPECT_EQ(catalogs[0], kAllowedCatalog);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, GetDbSchemasDeniesForbiddenCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  std::string blocked_catalog = kBlockedCatalog;
+  auto result = client->GetDbSchemas(call_options, &blocked_catalog, nullptr);
+  ASSERT_FALSE(result.ok());
+  ASSERT_NE(result.status().ToString().find("Access denied"), std::string::npos);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, GetTablesDeniesForbiddenCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  std::string blocked_catalog = kBlockedCatalog;
+  auto result = client->GetTables(call_options, &blocked_catalog, nullptr, nullptr, false,
+                                  nullptr);
+  ASSERT_FALSE(result.ok());
+  ASSERT_NE(result.status().ToString().find("Access denied"), std::string::npos);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, GetTablesWildcardCatalogPatternShowsOnlyAllowedCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  std::string wildcard_catalog = "%";
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto info,
+      client->GetTables(call_options, &wildcard_catalog, nullptr, nullptr, false, nullptr));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto table, CollectResults(*client, call_options, info));
+
+  auto catalogs = GetStringColumnValues(table, "catalog_name");
+  ASSERT_FALSE(catalogs.empty());
+  for (const auto& catalog : catalogs) {
+    EXPECT_EQ(catalog, kAllowedCatalog);
+  }
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, UseForbiddenCatalogIsDenied) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  auto result = client->Execute(call_options, "USE blocked_catalog");
+  ASSERT_FALSE(result.ok());
+  ASSERT_NE(result.status().ToString().find("Access denied"), std::string::npos);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, InformationSchemaTablesShowsOnlyAllowedCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  ASSERT_ARROW_OK(ExecuteAndConsume(*client, call_options, "USE allowed_catalog"));
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto table,
+      ExecuteToTable(*client, call_options,
+                     "SELECT DISTINCT table_catalog FROM information_schema.tables "
+                     "ORDER BY table_catalog"));
+
+  auto catalogs = GetStringColumnValues(table, "table_catalog");
+  ASSERT_EQ(catalogs.size(), 1);
+  EXPECT_EQ(catalogs[0], kAllowedCatalog);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, InformationSchemaSchemataShowsOnlyAllowedCatalog) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto table,
+      ExecuteToTable(*client, call_options,
+                     "SELECT DISTINCT catalog_name FROM information_schema.schemata "
+                     "ORDER BY catalog_name"));
+
+  auto catalogs = GetStringColumnValues(table, "catalog_name");
+  ASSERT_EQ(catalogs.size(), 1);
+  EXPECT_EQ(catalogs[0], kAllowedCatalog);
+}
+
+TEST_F(CatalogMetadataRestrictionFixture, MetadataQueryWithoutCatalogColumnsIsDenied) {
+  SKIP_WITHOUT_LICENSE();
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  std::string token = CreateRestrictedToken();
+  auto call_options = GetCallOptionsWithToken(token);
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client, CreateClientWithToken(token));
+
+  auto result = client->Execute(
+      call_options,
+      "SELECT table_name FROM information_schema.tables ORDER BY table_name");
+  ASSERT_FALSE(result.ok());
+  ASSERT_NE(result.status().ToString().find("must include catalog columns"),
+            std::string::npos);
+}
+
+}  // namespace

--- a/tests/integration/test_catalog_metadata_restrictions.cpp
+++ b/tests/integration/test_catalog_metadata_restrictions.cpp
@@ -25,8 +25,6 @@
 #include <vector>
 
 #include <jwt-cpp/jwt.h>
-#include <picojson.h>
-
 #include "arrow/api.h"
 #include "arrow/flight/sql/client.h"
 #include "arrow/flight/sql/types.h"


### PR DESCRIPTION
## Summary
- restrict metadata enumeration to catalogs visible to the session token
- block unauthorized `USE <catalog>` and explicit forbidden metadata lookups
- add integration coverage for FlightSQL metadata RPCs and raw `information_schema` queries

## Notes
- stacked on top of `duckdb-version` / PR #6
- local build/tests were not run here because `cmake` is not installed in this environment